### PR TITLE
fix: Fixed error where dropdown on lookupcontrol was hidden while typing

### DIFF
--- a/packages/apps/src/Components/Controls/LookupControl/LookupControl.tsx
+++ b/packages/apps/src/Components/Controls/LookupControl/LookupControl.tsx
@@ -259,8 +259,7 @@ export const LookupCoreControl: React.FC<LookupCoreControlProps> = ({
     const noResultText = app.getLocalization('noResults') ?? 'No results...';
     const loadingText = app.getLocalization('loading') ?? 'Loading...';
     const [freeformvalue, setfreeformvalue] = useState<string>();
-     
-
+    
     console.log("Lookup Control:", [label, disabled, isLoading, remoteItems, initialOptions, remoteOptions, options, filter, value, selectedValue, selectedKey, loadRemoteValue,
         !!value, typeof (selectedValue) === "undefined", !isLoadingRemoteData, remoteItems?.items.filter(x => x.id === value).length === 0]);
     return (<>
@@ -290,7 +289,7 @@ export const LookupCoreControl: React.FC<LookupCoreControlProps> = ({
 
         <ComboBox
             componentRef={ref}
-            disabled={disabled || isLoading}
+            disabled={disabled}
 
             ariaLabel={label}
             styles={{ optionsContainerWrapper: { maxHeight: "25vh" }, inputDisabled: { background: theme?.palette.neutralLight, color: "black" }, rootDisabled: { borderWidth: 1, borderStyle: "solid", borderColor: theme?.palette.black, background: theme?.palette.neutralLight } }}


### PR DESCRIPTION
Having isLoading toggle disabled was causing enough time for the combobox to rerender without the dropdown. When the combobox was enabled again, it started in a state where the dropdown was not visible.