### PR TITLE
feat: oninit and presave js hooks on forms

### DIFF
--- a/packages/apps/src/Components/Controls/LookupControl/LookupControl.tsx
+++ b/packages/apps/src/Components/Controls/LookupControl/LookupControl.tsx
@@ -30,7 +30,7 @@ import { FormRender } from "../../Forms/FormRender";
 import { FormValidation } from "../../Forms/FormValidation";
 import { useModelDrivenApp } from "../../../useModelDrivenApp";
 import { useEAVForm } from "@eavfw/forms";
-import { EAVFOrmOnChangeHandler } from "../../../../../forms/src/EAVFormContextActions";
+import { EAVFormOnChangeCallbackContext, EAVFOrmOnChangeHandler } from "../../../../../forms/src/EAVFormContextActions";
 import { useFormHost } from "../../Forms/ModelDrivenEntityViewer";
 import { useAsyncMemo } from "../../../../../hooks/src";
 
@@ -185,7 +185,7 @@ export const LookupCoreControl: React.FC<LookupCoreControlProps> = ({
      * Modals change data inline and first saved to db as part of triggering save data.
      * @param data
      */
-    const _onModalSubmit = useCallback((data: any) => {
+    const _onModalSubmit = useCallback((data: any, localctx: EAVFormOnChangeCallbackContext) => {
         console.log("Submitting Modal", data);
         //let o = localOptions.current;
         //if (o.filter(o => o.key === DUMMY_DATA_KEY).length === 0)
@@ -200,8 +200,11 @@ export const LookupCoreControl: React.FC<LookupCoreControlProps> = ({
         setSelectedKey(DUMMY_DATA_KEY);
         setDummyData(data);
 
-        onChange(props => {
-            props[logicalName.slice(0, -2)] = data
+        onChange((props, ctx: EAVFormOnChangeCallbackContext) => {
+            props[logicalName.slice(0, -2)] = data;
+            
+            ctx.autoSave = localctx?.autoSave;
+            
         });
 
     }, []);
@@ -216,7 +219,7 @@ export const LookupCoreControl: React.FC<LookupCoreControlProps> = ({
         index?: number) => {
 
         console.log("LookupControl: on change", [event, option, index]);
-        onChange(props => {
+        onChange(props => {            
             if (option?.key === "dummy") {
                 delete props[logicalName];
                 props[logicalName.slice(0, -2)] = dummyData
@@ -290,6 +293,7 @@ export const LookupCoreControl: React.FC<LookupCoreControlProps> = ({
         </Modal>
 
         <ComboBox
+            id={`${targetEntityName}_${logicalName}_combo`} 
             componentRef={ref}
             disabled={disabled}
 
@@ -350,7 +354,7 @@ export const LookupCoreControl: React.FC<LookupCoreControlProps> = ({
                     boxShadow: `rgb(0 0 0 / 13%) 0px 3.2px 7.2px 0px, rgb(0 0 0 / 11%) 0px 0.6px 1.8px 0px`
                 })}>
                     <Stack style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
-                        <CommandButton text={localization.new} styles={commandback} iconProps={emojiIcon}
+                        <CommandButton id={`${targetEntityName}_${logicalName}_new`} text={localization.new} styles={commandback} iconProps={emojiIcon}
                             onClick={(e) => _showModal()} />
                         <CommandButton text={localization.clear} styles={commandback} iconProps={emojiIconClear}
                             onClick={resetValue} />

--- a/packages/apps/src/Components/Forms/AutoForm/FormComponent.tsx
+++ b/packages/apps/src/Components/Forms/AutoForm/FormComponent.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useRef, useState } from "react";
+import React, { createContext, useEffect, useRef, useState } from "react";
 import { IPivotProps, Pivot, PivotItem } from "@fluentui/react";
 
 
@@ -9,6 +9,7 @@ import { EntityDefinition, FormDefinition, FormTabDefinition } from "@eavfw/mani
 import { useTabProvider } from "../Tabs/useTabProvider";
 import { OptionsFactory } from "./OptionsFactory";
 import { FormValidation } from "../FormValidation";
+import { ResolveFeature } from "../../../FeatureFlags";
 
 type FormComponentProps<T> = {
     form: FormDefinition;
@@ -62,7 +63,17 @@ const FormComponent = <T,>(props: FormComponentProps<T>) => {
             itemContainer: { flexGrow: 1 },
         };
 
-
+        useEffect(() => {
+            if (form.scripts?.onInit) {
+                Object.getOwnPropertyNames(form.scripts.onInit).forEach(name => {
+                    const onInit = ResolveFeature(form.scripts!.onInit![name]);
+                    if (onInit) {
+                        onInit(form, entity, formData);
+                    }
+                })
+    
+            }
+        },[]);
 
 
         if (form?.type === "QuickCreate") {

--- a/packages/apps/src/Components/Forms/FormRenderProps.ts
+++ b/packages/apps/src/Components/Forms/FormRenderProps.ts
@@ -1,4 +1,4 @@
-import { NestedType } from "@eavfw/manifest";
+import { FormDefinition, NestedType } from "@eavfw/manifest";
 import { FormValidation } from "./FormValidation";
 
 
@@ -11,7 +11,7 @@ export type FormRenderProps = {
     forms?: string[],
     formName?: string;
     dismissPanel: (ev: "save" | "cancel") => void,
-    onChange: (data: any) => void
+    onChange: (data: any, ctx?: any) => void
     entityName?: string;
     extraErrors?: FormValidation;
 }

--- a/packages/apps/src/Components/Forms/ModelDrivenEntityViewer.tsx
+++ b/packages/apps/src/Components/Forms/ModelDrivenEntityViewer.tsx
@@ -16,6 +16,7 @@ import { FormSelectorComponent } from "./FormSelectorComponent";
 import FormComponent from "./AutoForm/FormComponent";
 import { useAppInfo } from "../../useAppInfo";
 import { useFormChangeHandlerProvider } from "./useFormChangeHandler";
+import { useRibbon } from "../../Components/Ribbon";
 
 
 
@@ -338,6 +339,7 @@ export const ModelDrivenEntityViewer: React.FC<ModelDrivenEntityViewerProps> = (
 
     const { record: record2, onChangeCallback, extraErrors: extraErrors2 } = useFormChangeHandlerProvider();
     const { record = record2, entityName, formName, entity, onChange = onChangeCallback, related, extraErrors = extraErrors2 } = props;
+    const { events } = useRibbon();
    
    
 
@@ -510,10 +512,17 @@ export const ModelDrivenEntityViewer: React.FC<ModelDrivenEntityViewerProps> = (
             }
         }
 
+        
+
         console.log("FormData Changed", { changes: formdata, new: formdatamerger.current });
 
 
-        return onFormDataChange2(formdatamerger.current, { onCommit: onCommitCollector.current });
+        onFormDataChange2(formdatamerger.current, { onCommit: onCommitCollector.current });
+        setTimeout(() => {
+        if (ctx?.autoSave)
+        {
+            events.emit('onSave');
+        }});
     }, [onFormDataChange2]);
 
 

--- a/packages/forms/src/EAVFormContextActions.ts
+++ b/packages/forms/src/EAVFormContextActions.ts
@@ -1,7 +1,7 @@
 import { EAVFormContextState } from "./EAVFormContextState";
 
 
-export type EAVFormOnChangeCallbackContext = { skipValidation?: boolean, onCommit?: Function }
+export type EAVFormOnChangeCallbackContext = { skipValidation?: boolean, onCommit?: Function, autoSave?: boolean }
 export type EAVFormOnChangeCallback<T> = (props: T, ctx: EAVFormOnChangeCallbackContext) => void
 export type EAVFOrmOnChangeHandler<T> = (cb: EAVFormOnChangeCallback<T>) => void
 

--- a/packages/manifest/src/Forms/FormDefinition.ts
+++ b/packages/manifest/src/Forms/FormDefinition.ts
@@ -14,6 +14,14 @@ export type FormDefinition = {
         }
     };
     query?:any,
+    scripts?: {
+        onInit?: {
+            [name: string]: string;
+        };
+        preSave?: {
+            [name: string]: string;
+        };
+    };
     layout: {
         tabs: {
             [tabName: string]: FormTabDefinition;


### PR DESCRIPTION
Allows the use of script hooks in the manifest on forms. That can be implemented custom apps to add additional functionality to EAV. 

![image](https://github.com/EAVFW/EAVFW/assets/3397744/2fc92853-eb83-42a4-8893-0bf0e95d623e)


![image](https://github.com/EAVFW/EAVFW/assets/3397744/b7ffea94-5841-4a84-8e61-a4b85409fcbf)

You can add as many scripts of type onInit and preSave as you want. The value of the property shold be used when registering the feature. They are executed in the order they are listed in the manifest. 

To register the hooks with the app use: 
```
import { PreSaveValidatorResult } from "@eavfw/apps";
import { RegisterFeature } from "@eavfw/apps/src/FeatureFlags";
import { EntityDefinition, FormDefinition } from "@eavfw/manifest";

let i:number;

function validateTeacherFields(data: any, entity : EntityDefinition) : PreSaveValidatorResult{

    //fullname
    console.log('validateTeacherField');
    if (!data || !data.fullname || !data.initials || !data.jobtitleid)
    {
        return {success: false, msg: 'Alle felter skal udfyldes'};
    }
    
    return {success: true}
}

RegisterFeature("ValidateTeacherFields", validateTeacherFields);
```
