### PR TITLE
Rerender form on record change

### DIFF
--- a/packages/apps/src/Components/Forms/ModelDrivenEntityViewer.tsx
+++ b/packages/apps/src/Components/Forms/ModelDrivenEntityViewer.tsx
@@ -364,14 +364,6 @@ export const ModelDrivenEntityViewer: React.FC<ModelDrivenEntityViewerProps> = (
     //  const [etag, setEtag] = useState(new Date().toISOString());
 
     //  const outerRecord = useObservable(record, info.currentRecordId, info.currentEntityName);
-    /**
-     * When recordid or entityname changes, reset to other record.
-     **/
-    useEffect(() => {
-        console.log("Changing form record state from outside", [record, record?.name, info.currentRecordId, info.currentEntityName]);
-        formDataRef.current = record;
-        //  setEtag(new Date().toISOString());
-    }, [record]);
 
     const groups = useMemo(() => createRadioGroups(form, entity), [form, entity]);
 
@@ -525,6 +517,13 @@ export const ModelDrivenEntityViewer: React.FC<ModelDrivenEntityViewerProps> = (
         }});
     }, [onFormDataChange2]);
 
+    /**
+     * When recordid or entityname changes, reset to other record.
+     **/
+    useEffect(() => {
+        console.log("Changing form record state from outside", [record, record?.name, info.currentRecordId, info.currentEntityName]);
+        onFormDataChange(record)
+    }, [record]);
 
     return (
         <EAVForm defaultData={formDataRef.current} onChange={onFormDataChange}>

--- a/packages/forms/src/EAVForm.tsx
+++ b/packages/forms/src/EAVForm.tsx
@@ -397,7 +397,13 @@ export const EAVForm = <T extends {}, TState extends EAVFormContextState<T>>({
    
     const global_etag = useRef<string>(new Date().toISOString());
     const [etag, setEtag] = useState(new Date().toISOString());
-
+    
+    useEffect(() => {
+        console.log("eavform change", defaultData); 
+        state.formValues = cloneDeep(defaultData);
+        setEtag(global_etag.current = new Date().toISOString());
+    }, [defaultData])
+    
     useEffect(() => {
         if (blazor.isEnabled ) {
             let t = new Date().getTime();


### PR DESCRIPTION
Allows buttons to mutate the record and then trigger a rerender. Previously, this only mutated the record - did not trigger rerender