### PR TITLE
Added timeout to expression parser

### DIFF
--- a/packages/expressions/src/useExpressionParser.ts
+++ b/packages/expressions/src/useExpressionParser.ts
@@ -65,6 +65,7 @@ export function useExpressionParser<T = string>(expression?: string) {
                 }
               
                 if (oldvalue.current !== result) {
+                    //Using an timeout to make sure the render loop is completed beforethe value is changes. If not the value can change back after the new value is placed
                     setTimeout(() => {
                         setEvaluated({ data: result, isLoading: false });
                         //     setExpressionResult(id, result, undefined);

--- a/packages/expressions/src/useExpressionParser.ts
+++ b/packages/expressions/src/useExpressionParser.ts
@@ -65,9 +65,11 @@ export function useExpressionParser<T = string>(expression?: string) {
                 }
               
                 if (oldvalue.current !== result) {
-                    setEvaluated({ data: result, isLoading: false });
-               //     setExpressionResult(id, result, undefined);
-                    oldvalue.current = result;
+                    setTimeout(() => {
+                        setEvaluated({ data: result, isLoading: false });
+                        //     setExpressionResult(id, result, undefined);
+                        oldvalue.current = result;                                 
+                    }, 0);                 
                 }
 
 


### PR DESCRIPTION
Added a timeout to expression pareser.
This reorders the order of exectution, fixing an issue in the VandData project.

The issuse was, that sometimes the order of execution happenede in such an order, that the field changed it's value back to it's original value, efter changing to the new value from the expression.