### PR TITLE
Custom dashboards that are not related to any specific entity

### DIFF
--- a/packages/apps/src/Components/Dashboards/DashboardRegister.ts
+++ b/packages/apps/src/Components/Dashboards/DashboardRegister.ts
@@ -1,6 +1,0 @@
-
-export const Dashboards: { [key: string]: any } = {};
-
-export function RegisterDashboard(name: string, dashboard: any) {
-    Dashboards[name] = dashboard;
-}

--- a/packages/apps/src/Components/Dashboards/DashboardRegister.ts
+++ b/packages/apps/src/Components/Dashboards/DashboardRegister.ts
@@ -1,0 +1,6 @@
+
+export const Dashboards: { [key: string]: any } = {};
+
+export function RegisterDashboard(name: string, dashboard: any) {
+    Dashboards[name] = dashboard;
+}

--- a/packages/apps/src/Components/Navigation/ModelDrivenNavigation.tsx
+++ b/packages/apps/src/Components/Navigation/ModelDrivenNavigation.tsx
@@ -25,7 +25,7 @@ import React, { useEffect, useState } from 'react';
 import styles from "./ModelDrivenNavigation.module.scss";
 import { NextRouter, useRouter, } from 'next/router'
 import { ModelDrivenSitemap } from "../../ModelDrivenSitemap";
-import { ModelDrivenSitemapEntity } from "../../ModelDrivenSitemapEntity";
+import { ModelDrivenSitemapEntry } from "../../ModelDrivenSitemapEntry";
 import { useUserProfile } from "../Profile/useUserProfile";
 import { useAppInfo } from "../../useAppInfo";
 import { useModelDrivenApp } from "../../useModelDrivenApp";
@@ -101,7 +101,7 @@ const IconRight: IIconProps = {
 };
 
 function filterEntry(user: any) {
-    return ([key, entry]: [string, ModelDrivenSitemapEntity]) => {
+    return ([key, entry]: [string, ModelDrivenSitemapEntry]) => {
         console.log("filter entry");
         console.log([entry, user]);
 

--- a/packages/apps/src/Components/Navigation/ModelDrivenNavigation.tsx
+++ b/packages/apps/src/Components/Navigation/ModelDrivenNavigation.tsx
@@ -97,8 +97,6 @@ const IconRight: IIconProps = {
 
 function filterEntry(user: any) {
     return ([key, entry]: [string, ModelDrivenSitemapEntry]) => {
-        console.log("filter entry");
-        console.log([entry, user]);
 
         if (!entry.roles)
             return true;
@@ -108,17 +106,15 @@ function filterEntry(user: any) {
 }
 
 function generateLink(entry: ModelDrivenSitemapEntry, selectedArea: string, appName: string) {
-    console.log("Generating link");
     if (entry.type && entry.type === "dashboard") {
-        console.log("Generating link: dashboard");
-        return `/apps/${appName}/areas/${selectedArea}/dashboards/${entry.control}`;
+        console.log("entry", entry);
+        return `/apps/${appName}/areas/${selectedArea}/dashboards/${entry.logicalName}`;
     }
     if (entry.viewName) {
         return `/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}/views/${entry.viewName}`;
     } else {
         return `/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}`;
     }
-
 }
 
 export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps) {
@@ -140,9 +136,6 @@ export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps)
         console.groupCollapsed("AreaFilters");
         try {
             const areas = Object.keys(sitemap.areas).filter(area => {
-                console.log("area to filter");
-                console.log(sitemap.areas[area]);
-                console.log(user);
 
                 if (!user)
                     return true;
@@ -153,7 +146,6 @@ export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps)
                     for (let e of Object.keys(group)) {
                         let roles = group[e].roles;
 
-                        console.log(roles);
                         if (roles) {
                             noRoleInfoDefined = false;
                             if (roles?.allowed?.filter(role => user.role.filter((r: string) => role === r).length > 0)?.length ?? 0 > 0) {
@@ -174,10 +166,8 @@ export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps)
     }, [user])
 
     const _areaChanged = (value: React.FormEvent<HTMLDivElement>, option?: IDropdownOption, index?: number) => {
-        console.log(arguments);
         const selectedArea = option?.key as string;
         setselectedArea(selectedArea);
-        // this.setState({ selectedArea: option?.key as string });
         router.push(`/apps/${router.query.appname}/areas/${selectedArea}/`);
     }
 

--- a/packages/apps/src/Components/Navigation/ModelDrivenNavigation.tsx
+++ b/packages/apps/src/Components/Navigation/ModelDrivenNavigation.tsx
@@ -23,20 +23,15 @@ import {
 import Link from "next/link";
 import React, { useEffect, useState } from 'react';
 import styles from "./ModelDrivenNavigation.module.scss";
-import { NextRouter, useRouter, } from 'next/router'
+import { useRouter, } from 'next/router'
 import { ModelDrivenSitemap } from "../../ModelDrivenSitemap";
 import { ModelDrivenSitemapEntry } from "../../ModelDrivenSitemapEntry";
 import { useUserProfile } from "../Profile/useUserProfile";
 import { useAppInfo } from "../../useAppInfo";
 import { useModelDrivenApp } from "../../useModelDrivenApp";
 import { ResolveFeature } from "../../FeatureFlags";
-import { isMobileDevice, useIsMobileDevice } from "@eavfw/utils";
+import { useIsMobileDevice } from "@eavfw/utils";
 import { FluentProvider } from "@fluentui/react-components";
-
-
-interface WithRouterProps {
-    router: NextRouter
-}
 
 export interface ModelDrivenNavigationProps /*extends WithRouterProps, WithAppProps, WithUserProps*/ {
     sitemap: ModelDrivenSitemap
@@ -110,6 +105,20 @@ function filterEntry(user: any) {
 
         return entry.roles.allowed?.filter(r => user.role.filter((rr: string) => r === rr).length > 0)?.length ?? 0 > 0;
     };
+}
+
+function generateLink(entry: ModelDrivenSitemapEntry, selectedArea: string, appName: string) {
+    console.log("Generating link");
+    if (entry.type && entry.type === "dashboard") {
+        console.log("Generating link: dashboard");
+        return `/apps/${appName}/areas/${selectedArea}/dashboards/${entry.control}`;
+    }
+    if (entry.viewName) {
+        return `/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}/views/${entry.viewName}`;
+    } else {
+        return `/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}`;
+    }
+
 }
 
 export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps) {
@@ -207,15 +216,15 @@ export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps)
                                                                         <Icon iconName="AddInIcon" />
                                                                         {entry.viewName ?
                                                                             <Link legacyBehavior
-                                                                                href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}/views/${entry.viewName}`}>
+                                                                                href={generateLink(entry, selectedArea, appName)}>
                                                                                 <FluentLink
-                                                                                    href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}/views/${entry.viewName}`}>    {entry.title}</FluentLink>
+                                                                                    href={generateLink(entry, selectedArea, appName)}>    {entry.title}</FluentLink>
                                                                             </Link>
                                                                             :
                                                                             <Link legacyBehavior
-                                                                                href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}`}>
+                                                                                href={generateLink(entry, selectedArea, appName)}>
                                                                                 <FluentLink
-                                                                                    href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}`}>    {entry.title}</FluentLink>
+                                                                                    href={generateLink(entry, selectedArea, appName)}>    {entry.title}</FluentLink>
                                                                             </Link>
                                                                         }
                                                                     </Stack>
@@ -242,9 +251,9 @@ export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps)
                                                                     {entry.viewName ?
                                                                         <div>
                                                                             <Link legacyBehavior
-                                                                                href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}/views/${entry.viewName}`}>
+                                                                                href={generateLink(entry, selectedArea, appName)}>
                                                                                 <FluentLink
-                                                                                    href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}/views/${entry.viewName}`}>
+                                                                                    href={generateLink(entry, selectedArea, appName)}>
                                                                                     <Persona
                                                                                         imageInitials={entry.title.substring(0, 2).toUpperCase()}
                                                                                         initialsColor={PersonaInitialsColor.blue}
@@ -256,9 +265,9 @@ export default function ModelDrivenNavigation(props: ModelDrivenNavigationProps)
                                                                         :
                                                                         <div>
                                                                             <Link legacyBehavior
-                                                                                href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}`}>
+                                                                                href={generateLink(entry, selectedArea, appName)}>
                                                                                 <FluentLink
-                                                                                    href={`/apps/${appName}/areas/${selectedArea}/entities/${entry.logicalName}`}>
+                                                                                    href={generateLink(entry, selectedArea, appName)}>
 
                                                                                     <Persona
                                                                                         imageInitials={entry.title.substring(0, 2).toUpperCase()}

--- a/packages/apps/src/ModelDrivenApp.ts
+++ b/packages/apps/src/ModelDrivenApp.ts
@@ -76,10 +76,7 @@ export class ModelDrivenApp {
     }
 
     getDashboard(dashboardName: string) {
-        if (this._data.dashboards) {
-            return this._data.dashboards[dashboardName];
-        }
-        return undefined;
+        return this._data.dashboards?.[dashboardName];
     }
 
     getAttributes(entityName: string) {

--- a/packages/apps/src/ModelDrivenApp.ts
+++ b/packages/apps/src/ModelDrivenApp.ts
@@ -37,8 +37,6 @@ export class ModelDrivenApp {
         }
     }
 
-
-
     getConfig(key: string) {
         return this._data.config?.[key];
     }
@@ -75,6 +73,13 @@ export class ModelDrivenApp {
         if (!entityName)
             throw new Error("entityName not provided");
         return this._data.entities[entityName.toLowerCase().replace(/\s/g, "")];
+    }
+
+    getDashboard(dashboardName: string) {
+        if (this._data.dashboards) {
+            return this._data.dashboards[dashboardName];
+        }
+        return undefined;
     }
 
     getAttributes(entityName: string) {
@@ -223,8 +228,8 @@ export class ModelDrivenApp {
                                 if (form.type === "Main") {
                                     if ((formKey === formName || formName === form.name) && this.isMatchingForm(form, tabName, columnName, sectionName)) {
 
-                                        const viewName = form.view ?? Object.keys(entity?.views ?? {})[0];                                       
-                                                                         
+                                        const viewName = form.view ?? Object.keys(entity?.views ?? {})[0];
+
                                         const logicalname = attribute.type.inline ? Object.entries(entity.attributes)
                                             .filter(isAttributeLookupEntry)
                                             .filter(x => x[1].type.referenceType === this.getEntityKey(entityName))[0][1].logicalName : attribute.logicalName;
@@ -238,7 +243,7 @@ export class ModelDrivenApp {
                                             attributeType: attribute.type?.type,
                                             inlinePolyLookup: attribute.type?.inline,
                                             entity: entity,
-                                            filter:   form.filter,
+                                            filter: form.filter,
                                             key: entity.logicalName + attribute.logicalName
                                         });
                                     } else {

--- a/packages/apps/src/ModelDrivenAppModel.ts
+++ b/packages/apps/src/ModelDrivenAppModel.ts
@@ -6,6 +6,7 @@ export interface ModelDrivenAppModel {
     sitemap: ModelDrivenSitemap;
     title: string;
     entities: ManifestDefinition["entities"];
+    dashboards: ManifestDefinition["dashboards"];
     entityMap: { [key: string]: string };
     entityCollectionSchemaNameMap: { [key: string]: string };
     apps: { [key: string]: any };

--- a/packages/apps/src/ModelDrivenAppModel.ts
+++ b/packages/apps/src/ModelDrivenAppModel.ts
@@ -6,7 +6,7 @@ export interface ModelDrivenAppModel {
     sitemap: ModelDrivenSitemap;
     title: string;
     entities: ManifestDefinition["entities"];
-    dashboards: ManifestDefinition["dashboards"];
+    dashboards?: ManifestDefinition["dashboards"];
     entityMap: { [key: string]: string };
     entityCollectionSchemaNameMap: { [key: string]: string };
     apps: { [key: string]: any };

--- a/packages/apps/src/ModelDrivenSitemap.ts
+++ b/packages/apps/src/ModelDrivenSitemap.ts
@@ -1,4 +1,4 @@
-import { ModelDrivenSitemapEntry as ModelDrivenSitemapEntry } from "./ModelDrivenSitemapEntry";
+import { ModelDrivenSitemapEntry } from "./ModelDrivenSitemapEntry";
 
 export interface ModelDrivenSitemap {
     areas: {

--- a/packages/apps/src/ModelDrivenSitemap.ts
+++ b/packages/apps/src/ModelDrivenSitemap.ts
@@ -1,18 +1,10 @@
-import { ModelDrivenSitemapEntity } from "./ModelDrivenSitemapEntity";
+import { ModelDrivenSitemapEntry as ModelDrivenSitemapEntry } from "./ModelDrivenSitemapEntry";
 
 export interface ModelDrivenSitemap {
-    dashboards: {
-        [area: string]: {
-            [dashboard: string]: {
-                url: string
-            }
-        }
-    },
     areas: {
         [key: string]: {
             [key: string]: {
-
-                [key: string]: ModelDrivenSitemapEntity
+                [key: string]: ModelDrivenSitemapEntry
             };
         };
     };

--- a/packages/apps/src/ModelDrivenSitemapEntry.ts
+++ b/packages/apps/src/ModelDrivenSitemapEntry.ts
@@ -1,8 +1,10 @@
 
-export interface ModelDrivenSitemapEntity {
+export interface ModelDrivenSitemapEntry {
+    type: "dashboard" | "entity";
     logicalName: string;
     pluralName: string;
     viewName?: string;
+    control?: string;
     title: string;
     roles?: {
         allowed?: Array<string>

--- a/packages/apps/src/generateAppContext.ts
+++ b/packages/apps/src/generateAppContext.ts
@@ -1,5 +1,14 @@
-import { EntityDefinition, isSingleSiteMapDefinition, ManifestDefinition, PrimitiveType, SiteMapDefinition } from "@eavfw/manifest";
+import { DashboardDefinition, EntityDefinition, isSingleSiteMapDefinition, ManifestDefinition, PrimitiveType, SiteMapDefinition } from "@eavfw/manifest";
 import { ModelDrivenAppModel } from "./ModelDrivenAppModel";
+
+type AreasType = {
+    [area: string]: {
+        [group: string]: {
+            [key: string]: (EntityDefinition & Required<SiteMapDefinition>)
+        }
+    }
+
+};
 
 function sortObj<T>(areas: { [key: string]: T }, sort: (a: T, ai: number, b: T, bi: number) => number, childMapper: (a: T) => T) {
     let keys = Object.keys(areas);
@@ -13,30 +22,56 @@ function sortObj<T>(areas: { [key: string]: T }, sort: (a: T, ai: number, b: T, 
         }, {} as any);
 }
 
+function sortAreas(areas: AreasType) {
+    return sortObj(areas, (a, ai, b, bi) => {
+        const aa = Math.max(-1000 + ai, Math.max(-1000 + ai, ...Object.values(a).map(x => Object.values(x).map(xx => xx.order)).flat()));
+        const ab = Math.min(1000 - bi, ...Object.values(b).map(x => Object.values(x).map(xx => xx.order)).flat());
+        return aa - ab;
+    }, x => {
+        return sortObj(x, (a, ai, b, bi) => {
+            return ai - bi;
+        }, x => {
+            return sortObj(x, (a, ai, b, bi) => {
+                return (a.order ?? ai) - (b.order ?? bi);
+            }, x => x);
+
+        });
+    });
+}
+
+function isEntityDefinition(item: any): item is EntityDefinition {
+    if (typeof item !== 'object' || item === null) {
+        return false;
+    }
+    return 'logicalName' in item && typeof item.logicalName === 'string' &&
+        'collectionSchemaName' in item && typeof item.collectionSchemaName === 'string' &&
+        'attributes' in item && typeof item.attributes === 'object';
+}
+
 function normalizeType(attribute: { type: PrimitiveType | { type: PrimitiveType } }): void {
     if (typeof attribute.type !== "string")
         attribute.type.type = attribute.type.type.toLowerCase() as PrimitiveType;
     else attribute.type = attribute.type.toLowerCase() as PrimitiveType;
 }
 
+function processItems(items: { [key: string]: EntityDefinition | DashboardDefinition }, areas: any, entityMap: { [key: string]: string }, entityCollectionSchemaNameMap: { [key: string]: string }, itemType: string) {
+    // for (const key in items) {
+    //     const item = items[key];
+    //     if (isEntityDefinition(item) && item.attributes) {
+    //         Object.values(item.attributes).forEach(normalizeType);
+    //     }
+    //     entityMap[key] = item.logicalName;
+    //     entityCollectionSchemaNameMap[item.collectionSchemaName] = item.logicalName;
 
-export function generateAppContext(manifest: ManifestDefinition): ModelDrivenAppModel {
+    //     processSiteMaps(item.sitemap, areas, item, key, itemType);
+    // }
+    for (const entityKey of Object.keys(items)) {
 
-    const areas: {
-        [area: string]: {
-            [group: string]: {
-                [key: string]: (EntityDefinition & Required<SiteMapDefinition>)
-            }
+        if (isEntityDefinition(entityKey) && entityKey.attributes) {
+            Object.values(entityKey.attributes).forEach(normalizeType);
         }
-    } = {};
 
-    const entityMap: { [entityKey: string]: string } = {};
-    const entityCollectionSchemaNameMap: { [entityKey: string]: string } = {};
-
-    for (const entityKey of Object.keys(manifest.entities)) {
-        Object.values(manifest.entities[entityKey].attributes).forEach(normalizeType);
-
-        const entity = manifest.entities[entityKey];
+        const entity = items[entityKey];
         entityMap[entityKey] = entity.logicalName;
         entityCollectionSchemaNameMap[entity.collectionSchemaName] = entity.logicalName;
 
@@ -60,45 +95,50 @@ export function generateAppContext(manifest: ManifestDefinition): ModelDrivenApp
             }
         }
     }
+}
+
+function processSiteMaps(sitemaps: any, areas: any, item: EntityDefinition | DashboardDefinition, itemKey: string, itemType: string) {
+    if (typeof sitemaps === 'object' && !isSingleSiteMapDefinition(sitemaps)) {
+        sitemaps = { [`${itemKey}Dummy`]: sitemaps };
+    }
+    for (const sitemapKey in sitemaps) {
+        const sitemap = sitemaps[sitemapKey];
+        const { area, group } = sitemap;
+        areas[area] = areas[area] || {};
+        areas[area][group] = areas[area][group] || {};
+        areas[area][group][sitemapKey] = areas[area][group][sitemapKey] || { ...item, title: item.locale?.["1030"]?.pluralName ?? item.pluralName, order: 0 };
+        areas[area][group][sitemapKey] = {
+            ...areas[area][group][sitemapKey],
+            ...sitemap,
+            title: sitemap.title ?? sitemap.locale?.["1030"].displayName ?? item.locale?.["1030"].pluralName ?? item.pluralName
+        };
+    }
+}
 
 
-    const areaSorted = sortObj(areas, (a, ai, b, bi) => {
+export function generateAppContext(manifest: ManifestDefinition): ModelDrivenAppModel {
+    const areas: AreasType = {};
+    const entityMap: { [entityKey: string]: string } = {};
+    const entityCollectionSchemaNameMap: { [entityKey: string]: string } = {};
 
-        var aa = Math.max(-1000 + ai, ...Object.values(a).map(x => Object.values(x).map(xx => xx.order)).flat());
-        var ab = Math.min(1000 - bi, ...Object.values(b).map(x => Object.values(x).map(xx => xx.order)).flat());
+    if (manifest.dashboards) {
+        processItems(manifest.dashboards, areas, entityMap, entityCollectionSchemaNameMap, 'dashboard');
+    }
+    processItems(manifest.entities, areas, entityMap, entityCollectionSchemaNameMap, 'entity');
 
-        return aa - ab;
-    }, x => {
+    const areaSorted = sortAreas(areas);
+    console.log("AREAS", areaSorted);
 
-        return sortObj(x, (a, ai, b, bi) => {
-
-            var aa = Math.max(-1000 + ai, ...Object.values(a).map(xx => xx.order));
-            var ab = Math.min(1000 - bi, ...Object.values(b).map(xx => xx.order));
-
-            return ai - bi;
-        }, x => {
-
-            return sortObj(x, (a, ai, b, bi) => {
-                return (a.order ?? ai) - (b.order ?? bi);
-            }, x => x);
-
-        });
-    });
-
-    const defaultApp: ModelDrivenAppModel = {
+    return {
         localization: manifest.localization,
         errorMessages: manifest.errorMessages,
         config: manifest.config,
-        title: Object.keys(manifest.apps)[0], // "Arbejdstid",
-        dashboards: manifest.dashboards ? Object.assign({}, ...Object.values(manifest.dashboards).map((o) => ({ [o.logicalName]: o }))) : {},
-        entities: Object.assign({}, ...Object.values(manifest.entities).map((o) => ({ [o.logicalName]: o }))),
+        title: Object.keys(manifest.apps)[0],
+        dashboards: manifest.dashboards ? Object.assign({}, ...Object.values(manifest.dashboards).map(o => ({ [o.logicalName]: o }))) : {},
+        entities: Object.assign({}, ...Object.values(manifest.entities).map(o => ({ [o.logicalName]: o }))),
         entityMap: entityMap,
         entityCollectionSchemaNameMap: entityCollectionSchemaNameMap,
         apps: manifest.apps,
-        sitemap: {
-            areas: areaSorted
-        },
+        sitemap: { areas: areaSorted }
     };
-
-    return defaultApp;
 }

--- a/packages/apps/src/generateAppContext.ts
+++ b/packages/apps/src/generateAppContext.ts
@@ -65,27 +65,27 @@ function processItems(items: { [key: string]: EntityDefinition | DashboardDefini
 
     //     processSiteMaps(item.sitemap, areas, item, key, itemType);
     // }
-    for (const entityKey of Object.keys(items)) {
+    for (const key of Object.keys(items)) {
 
-        if (isEntityDefinition(entityKey) && entityKey.attributes) {
-            Object.values(entityKey.attributes).forEach(normalizeType);
+        if (isEntityDefinition(key) && key.attributes) {
+            Object.values(key.attributes).forEach(normalizeType);
         }
 
-        const entity = items[entityKey];
-        entityMap[entityKey] = entity.logicalName;
+        const entity = items[key];
+        entityMap[key] = entity.logicalName;
         entityCollectionSchemaNameMap[entity.collectionSchemaName] = entity.logicalName;
 
         let sitemaps = entity.sitemap;
         if (typeof sitemaps === "object") {
-            if (isSingleSiteMapDefinition(sitemaps)) sitemaps = { [`${entityKey}dummy`]: sitemaps };
+            if (isSingleSiteMapDefinition(sitemaps)) sitemaps = { [`${key}dummy`]: sitemaps };
 
-            for (const sitemapKey1 of Object.keys(sitemaps)) {
-                const sitemap = sitemaps[sitemapKey1];
+            for (const sitemapKey of Object.keys(sitemaps)) {
+                const sitemap = sitemaps[sitemapKey];
 
                 if (sitemap !== undefined && areas[sitemap.area] === undefined) areas[sitemap.area] = {};
                 areas[sitemap.area][sitemap.group] = areas[sitemap.area][sitemap.group] ?? {};
-                areas[sitemap.area][sitemap.group][sitemapKey1] = {
-                    ... (areas[sitemap.area][sitemap.group][sitemapKey1]
+                areas[sitemap.area][sitemap.group][sitemapKey] = {
+                    ... (areas[sitemap.area][sitemap.group][sitemapKey]
                         ?? { ...entity, title: entity.locale?.["1030"]?.pluralName ?? entity.pluralName, order: 0 }), ...{
 
                             ...sitemap,
@@ -127,7 +127,6 @@ export function generateAppContext(manifest: ManifestDefinition): ModelDrivenApp
     processItems(manifest.entities, areas, entityMap, entityCollectionSchemaNameMap, 'entity');
 
     const areaSorted = sortAreas(areas);
-    console.log("AREAS", areaSorted);
 
     return {
         localization: manifest.localization,

--- a/packages/apps/src/generateAppContext.ts
+++ b/packages/apps/src/generateAppContext.ts
@@ -12,43 +12,43 @@ function sortObj<T>(areas: { [key: string]: T }, sort: (a: T, ai: number, b: T, 
             return accumulator;
         }, {} as any);
 }
+
+function normalizeType(attribute: { type: PrimitiveType | { type: PrimitiveType } }): void {
+    if (typeof attribute.type !== "string")
+        attribute.type.type = attribute.type.type.toLowerCase() as PrimitiveType;
+    else attribute.type = attribute.type.toLowerCase() as PrimitiveType;
+}
+
+
 export function generateAppContext(manifest: ManifestDefinition): ModelDrivenAppModel {
 
-    //console.group("generateAppContext");
-    //console.log("ALERT: Generating Model");
+    const areas: {
+        [area: string]: {
+            [group: string]: {
+                [key: string]: (EntityDefinition & Required<SiteMapDefinition>)
+            }
+        }
+    } = {};
 
-    const areas: { [area: string]: { [group: string]: { [key: string]: EntityDefinition & Required<SiteMapDefinition> } } } = {};
-    const dashboards: { [area: string]: any } = {};
     const entityMap: { [entityKey: string]: string } = {};
     const entityCollectionSchemaNameMap: { [entityKey: string]: string } = {};
 
     for (const entityKey of Object.keys(manifest.entities)) {
-        //Fix all lowercase types on load
-        for (const attribute of Object.values(manifest.entities[entityKey].attributes)) {
-            if (typeof attribute.type !== "string")
-                attribute.type.type = attribute.type.type.toLowerCase() as PrimitiveType;
-            else attribute.type = attribute.type.toLowerCase() as PrimitiveType;
-        }
+        Object.values(manifest.entities[entityKey].attributes).forEach(normalizeType);
 
         const entity = manifest.entities[entityKey];
         entityMap[entityKey] = entity.logicalName;
         entityCollectionSchemaNameMap[entity.collectionSchemaName] = entity.logicalName;
 
         let sitemaps = entity.sitemap;
-        //  console.log(`${entityKey} :`, sitemaps)
         if (typeof sitemaps === "object") {
             if (isSingleSiteMapDefinition(sitemaps)) sitemaps = { [`${entityKey}dummy`]: sitemaps };
 
             for (const sitemapKey1 of Object.keys(sitemaps)) {
                 const sitemap = sitemaps[sitemapKey1];
-                const sitemapKey = entityKey;
 
                 if (sitemap !== undefined && areas[sitemap.area] === undefined) areas[sitemap.area] = {};
-                if (sitemap !== undefined && dashboards[sitemap.area] === undefined) dashboards[sitemap.area] = {};
-
                 areas[sitemap.area][sitemap.group] = areas[sitemap.area][sitemap.group] ?? {};
-                // console.log("Adding sitemapkey before", [sitemapKey, sitemapKey1, areas[sitemap.area][sitemap.group][sitemapKey1], entity, sitemap]);
-
                 areas[sitemap.area][sitemap.group][sitemapKey1] = {
                     ... (areas[sitemap.area][sitemap.group][sitemapKey1]
                         ?? { ...entity, title: entity.locale?.["1030"]?.pluralName ?? entity.pluralName, order: 0 }), ...{
@@ -57,8 +57,6 @@ export function generateAppContext(manifest: ManifestDefinition): ModelDrivenApp
                             title: sitemap.title ?? sitemap.locale?.["1030"].displayName ?? sitemap.locale?.["1030"]?.pluralName ?? entity.locale?.["1030"]?.pluralName ?? entity.pluralName
                         }
                 };
-                //  console.log("Adding sitemapkey after", [sitemapKey, sitemapKey1, areas[sitemap.area][sitemap.group][sitemapKey1], entity, sitemap]);
-                dashboards[sitemap.area] = Object.assign(dashboards[sitemap.area], sitemap.dashboards);
             }
         }
     }
@@ -87,14 +85,12 @@ export function generateAppContext(manifest: ManifestDefinition): ModelDrivenApp
         });
     });
 
-    // console.log("areas:\n", areaSorted);
-    //  console.log("dashboards:\n", dashboards);
     const defaultApp: ModelDrivenAppModel = {
         localization: manifest.localization,
         errorMessages: manifest.errorMessages,
         config: manifest.config,
         title: Object.keys(manifest.apps)[0], // "Arbejdstid",
-        dashboards: dashboards,
+        dashboards: manifest.dashboards ? Object.assign({}, ...Object.values(manifest.dashboards).map((o) => ({ [o.logicalName]: o }))) : {},
         entities: Object.assign({}, ...Object.values(manifest.entities).map((o) => ({ [o.logicalName]: o }))),
         entityMap: entityMap,
         entityCollectionSchemaNameMap: entityCollectionSchemaNameMap,
@@ -104,6 +100,5 @@ export function generateAppContext(manifest: ManifestDefinition): ModelDrivenApp
         },
     };
 
-    //  console.groupEnd();
     return defaultApp;
 }

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -4,7 +4,7 @@ export * from "./useModelDrivenApp";
 export * from "./ModelDrivenApp";
 export * from "./FormsConfig";
 export * from "./ModelDrivenSitemap";
-export * from "./ModelDrivenSitemapEntity";
+export * from "./ModelDrivenSitemapEntry";
 export * from "./AppNavigationContextProps";
 export * from "./AppNavigationContextProvider";
 export * from "./AppInfoProvider";

--- a/packages/manifest/src/Entities/EntityDefinition.ts
+++ b/packages/manifest/src/Entities/EntityDefinition.ts
@@ -79,6 +79,7 @@ export type EntityDefinition = {
     displayName: string;
     schemaName: string;
     logicalName: string;
+    control?: string;
     locale?: { [locale: string]: LocaleDefinition };
     sitemap?: MultipleSiteMapDefinitions | SiteMapDefinition;
     attributes: { [attribute: string]: AttributeDefinition };

--- a/packages/manifest/src/Entities/EntityDefinition.ts
+++ b/packages/manifest/src/Entities/EntityDefinition.ts
@@ -15,12 +15,12 @@ export type WizardTrigger = {
     form?: string | WizardFormTrigger
 }
 export type WizardTriggers = {
-    [key: string]:WizardTrigger
+    [key: string]: WizardTrigger
 
 }
 export type IWizardMessageToast = {
     timeout?: number
-    }
+}
 export type IWizardMessage = {
     intent?: 'info' | 'success' | 'warning' | 'error';
     title: string;
@@ -50,7 +50,7 @@ export type WizardTab = {
             title: string;
         };
     };
-    columns: FormTabDefinitionWithColumns["columns"]; 
+    columns: FormTabDefinitionWithColumns["columns"];
     onTransitionOut?: {
         workflow: string
     },
@@ -63,13 +63,13 @@ export type WizardTab = {
 }
 export type WizardTabsDefinition = {
     [key: string]: WizardTab;
-    }
+}
 export type WizardsDefinition = {
     triggers: WizardTriggers;
     tabs: WizardTabsDefinition;
     title: string;
 }
-export type WizardsCollection= {
+export type WizardsCollection = {
     [key: string]: WizardsDefinition
 }
 
@@ -90,5 +90,13 @@ export type EntityDefinition = {
     views?: EntityViewsDefinition,
     validation?: { [validationKey: string]: ValidationDefinitionV1 | ValidationDefinitionV2 }
     wizards?: WizardsCollection
+    [x: string]: any
+};
+
+export type DashboardDefinition = {
+    pluralName: string;
+    control?: string;
+    locale?: { [locale: string]: LocaleDefinition };
+    sitemap?: MultipleSiteMapDefinitions | SiteMapDefinition;
     [x: string]: any
 };

--- a/packages/manifest/src/Entities/EntityDefinition.ts
+++ b/packages/manifest/src/Entities/EntityDefinition.ts
@@ -94,6 +94,7 @@ export type EntityDefinition = {
 };
 
 export type DashboardDefinition = {
+    key: string;
     pluralName: string;
     control?: string;
     locale?: { [locale: string]: LocaleDefinition };

--- a/packages/manifest/src/ManifestDefinition.ts
+++ b/packages/manifest/src/ManifestDefinition.ts
@@ -8,6 +8,6 @@ export type ManifestDefinition = {
     variables: any;
     apps: any;
     entities: { [entity: string]: EntityDefinition };
-    dashboards: { [dashboard: string]: EntityDefinition }
+    dashboards?: { [dashboard: string]: EntityDefinition }
     errorMessages?: { [locale: string]: { [code: string]: string } }
 };

--- a/packages/manifest/src/ManifestDefinition.ts
+++ b/packages/manifest/src/ManifestDefinition.ts
@@ -1,6 +1,6 @@
 
 import { LocalizationDefinition } from "./Localization"
-import { EntityDefinition } from "./Entities";
+import { DashboardDefinition, EntityDefinition } from "./Entities";
 
 export type ManifestDefinition = {
     localization?: { [locale: string]: LocalizationDefinition };
@@ -8,6 +8,6 @@ export type ManifestDefinition = {
     variables: any;
     apps: any;
     entities: { [entity: string]: EntityDefinition };
-    dashboards?: { [dashboard: string]: EntityDefinition }
-    errorMessages?: { [locale: string]: { [code: string]: string } }
+    dashboards?: { [dashboard: string]: DashboardDefinition };
+    errorMessages?: { [locale: string]: { [code: string]: string } };
 };

--- a/packages/manifest/src/ManifestDefinition.ts
+++ b/packages/manifest/src/ManifestDefinition.ts
@@ -8,5 +8,6 @@ export type ManifestDefinition = {
     variables: any;
     apps: any;
     entities: { [entity: string]: EntityDefinition };
+    dashboards: { [dashboard: string]: EntityDefinition }
     errorMessages?: { [locale: string]: { [code: string]: string } }
 };


### PR DESCRIPTION
This pull request allows the definition of custom dashboards in the manifest that are not related to any specific entity. Thus requiring the developer to write a custom dashboard component that handles data access and rendering completely.